### PR TITLE
email hidden in json response to rakings

### DIFF
--- a/src/api/models.py
+++ b/src/api/models.py
@@ -39,14 +39,22 @@ class User(db.Model):
         backref='friend_of'
     )
 
-    def serialize(self):
+    def serialize_public(self):
         return {
             "id": self.id,
-            "email": self.email,
             "experience_points": self.experience_points,
             "friends": [friend.id for friend in self.friends],
             "user_info": self.user_info.serialize() if (self.user_info) else None
+
         }
+
+    def serialize_private(self):
+        return       { 
+            "email": self.email,
+
+    }
+
+    
 
     def add_friend(self, other_user):
         if other_user not in self.friends:

--- a/src/app.py
+++ b/src/app.py
@@ -201,7 +201,7 @@ def trivia_question():
 def global_ranking():
     try:
         results = get_global_ranking()
-        serialized_results = [result.serialize() for result in results]
+        serialized_results = [result.serialize_public() for result in results]
         return jsonify(serialized_results), 200
     except Exception as e:
         return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
When refreshing the ranking page, JSON shared the email information with users, now hidden in "serialize_private" @ models.
- "user_info" needs a refactor to hide personal data while making it work to render friends ranking properly. (wip) 